### PR TITLE
Enable deleteOnError based on fileExistsStrategy

### DIFF
--- a/lib/src/download_manager.dart
+++ b/lib/src/download_manager.dart
@@ -650,7 +650,10 @@ class DownloadManager {
             ); // Example: Signal unknown size
           }
         },
-        // deleteOnError: true, // Consider Dio deleting partial file on Dio error
+        deleteOnError:
+            fileExistsStrategy !=
+            FileExistsStrategy
+                .resume, // Consider Dio deleting partial file on Dio error
       );
 
       /// Check for cancellation *after* download completes (less likely but possible)


### PR DESCRIPTION
Sets the deleteOnError parameter to true unless the fileExistsStrategy is set to resume, ensuring partial files are deleted on errors except when resuming downloads.